### PR TITLE
Fix localStorage check when used in iframes

### DIFF
--- a/speech-commands/src/browser_fft_recognizer.ts
+++ b/speech-commands/src/browser_fft_recognizer.ts
@@ -33,10 +33,40 @@ export const SAVED_MODEL_METADATA_KEY =
     'tfjs-speech-commands-saved-model-metadata';
 export const SAVE_PATH_PREFIX = 'indexeddb://tfjs-speech-commands-model/';
 
+/**
+ * Cross-browser way to check for localStorage
+ * necessary eg. when embedded in iframes
+ * from: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Feature-detecting_localStorage
+ */
+function storageAvailable(type) {
+    var storage;
+    try {
+        storage = window[type];
+        var x = '__storage_test__';
+        storage.setItem(x, x);
+        storage.removeItem(x);
+        return true;
+    }
+    catch(e) {
+        return e instanceof DOMException && (
+            // everything except Firefox
+            e.code === 22 ||
+            // Firefox
+            e.code === 1014 ||
+            // test name field too, because code might not be present
+            // everything except Firefox
+            e.name === 'QuotaExceededError' ||
+            // Firefox
+            e.name === 'NS_ERROR_DOM_QUOTA_REACHED') &&
+            // acknowledge QuotaExceededError only if there's something already stored
+            (storage && storage.length !== 0);
+    }
+}
+
 // Export a variable for injection during unit testing.
 // tslint:disable-next-line:no-any
 export let localStorageWrapper = {
-  localStorage: typeof window === 'undefined' ? null : window.localStorage
+  localStorage: (typeof window === 'undefined' || !storageAvailable('localStorage')) ? null : window.localStorage
 };
 
 export function getMajorAndMinorVersion(version: string) {


### PR DESCRIPTION
When using the code in iframes that don't have the `sandbox="allow-same-origin"` attribute, it throws a DOMException when accessing `window.localStorage`. Breaking the whole script.
This fix relies on MDN's approach to check for the availability of localStorage [0].

[0]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API/Using_the_Web_Storage_API#Feature-detecting_localStorage